### PR TITLE
SIM-2534: Store conversations and add then to prompt

### DIFF
--- a/fable_agents/api.py
+++ b/fable_agents/api.py
@@ -8,8 +8,9 @@ from typing import List, Callable, Optional, Any, Dict
 from cattr import unstructure
 
 from fable_agents import ai
-from models import Persona, Vector3, StatusUpdate, Message, ObservationEvent, SequenceUpdate, MetaAffordanceProvider
-from fable_agents.datastore import Datastore, MetaAffordances
+from models import Persona, Vector3, StatusUpdate, Message, ObservationEvent, SequenceUpdate, MetaAffordanceProvider, \
+    Conversation
+from fable_agents.datastore import Datastore, MetaAffordances, ConversationMemory
 import socketio
 
 from langchain.chat_models import ChatOpenAI
@@ -75,6 +76,21 @@ class Format:
             'name': provider.sim_object.display_name,
             'description': provider.sim_object.description,
             'interactions': provider.affordances
+        }
+
+    @staticmethod
+    def conversation(conversation: Conversation, current_datetime: datetime):
+
+        turns = []
+        for turn in conversation.turns:
+            turns.append({
+                'persona_guid': turn.guid,
+                'dialogue': turn.dialogue,
+            })
+
+        return {
+            'time_ago': str(int((current_datetime - conversation.timestamp).total_seconds() / 60)) + 'm ago',
+            'transcript': turns,
         }
 
 
@@ -161,11 +177,12 @@ class GaiaAPI:
                     event.summary = observation.get('summary_of_activity', '')
                     event.importance = observation.get('summary_of_activity', 0)
                     Datastore.memory_vectors.memory_vectors.save_context({'observation_event': event},{'summary_of_activity': event.summary, 'importance': event.importance})
-        Datastore.observation_memory.set_observations(initiator_persona.guid, observer_update.timestamp, observation_events.values())
+        Datastore.observation_memory.set_observations(initiator_persona.guid, observer_update.timestamp, list(observation_events.values()))
         return intelligent_observations
 
     async def create_reactions(self, observer_update: StatusUpdate, observations: List[ObservationEvent],
                                sequences: [List[SequenceUpdate]], metaaffordances: MetaAffordances,
+                               conversations: List[Conversation],
                                ignore_continue: bool = False) -> List[Dict[str, Any]]:
 
         initiator_persona = Datastore.personas.personas.get(observer_update.guid, None)
@@ -191,6 +208,7 @@ class GaiaAPI:
                                 observations=json.dumps([Format.observation_event(evt) for evt in observations]),
                                 sequences=json.dumps([Format.sequence_update(seq) for seq in sequences]),
                                 action_options=json.dumps(action_options),
+                                conversations=json.dumps([Format.conversation(convo, observer_update.timestamp) for convo in conversations]),
                                 interact_options=json.dumps(
                                     [Format.interaction_option(affordance) for affordance in metaaffordances.affordances.values()])
                                 )

--- a/fable_agents/datastore.py
+++ b/fable_agents/datastore.py
@@ -107,7 +107,26 @@ class SequenceUpdates:
         return self.sequence_updates.get(persona_id, [])[-n:]
 
 
+class ConversationMemory:
+
+    conversations: Dict[str, List[models.Conversation]] = {}
+
+    def add(self, conversation: models.Conversation) -> None:
+        """
+        Add a conversation to the memory. Indexed by speakers guids.
+        :param conversation:
+        """
+        guids = set([turn.guid for turn in conversation.turns])
+        for guid in guids:
+            conversations = self.conversations.get(guid, [])
+            conversations.append(conversation)
+            self.conversations[guid] = conversations
+
+    def get(self, guid) -> List[models.Conversation]:
+        return self.conversations.get(guid, [])
+
 class Datastore:
+    conversations: ConversationMemory = ConversationMemory()
     observation_memory: ObservationMemory = ObservationMemory()
     personas: Personas = Personas()
     meta_affordances: MetaAffordances = MetaAffordances()

--- a/fable_agents/models.py
+++ b/fable_agents/models.py
@@ -1,6 +1,6 @@
 import json
 import datetime
-from typing import Any, Optional
+from typing import Any, Optional, List
 
 from attrs import define
 from cattrs import structure, unstructure
@@ -139,7 +139,7 @@ class SequenceStep:
 @define(slots=True)
 class Conversation:
     timestamp: datetime.datetime
-    turns: ['ConversationTurn']
+    turns: List['ConversationTurn']
 
     @staticmethod
     def from_dict(timestamp: datetime.datetime, obj: dict):

--- a/fable_agents/prompt_templates/actions_v1.yaml
+++ b/fable_agents/prompt_templates/actions_v1.yaml
@@ -1,6 +1,6 @@
 _type: prompt
 input_variables:
-    ["time", "self_description", "self_update", "observations", "sequences", "action_options", "interact_options"]
+    ["time", "self_description", "self_update", "observations", "sequences", "action_options", "interact_options", "conversations"]
 template: |
     You are an NPC character in a small western town of the late 1800s and described as follows:
     {self_description}
@@ -13,6 +13,9 @@ template: |
     
     Many characters exist in this world doing various activities right now. You noticed the following:
     {observations}
+    
+    You had the following conversations recently:
+    {conversations}
   
     Staying true to your character's personality and circumstance, create a list of actions you would like to take.
     You can choose between one and four actions created from the following json:

--- a/fable_agents/server.py
+++ b/fable_agents/server.py
@@ -79,8 +79,10 @@ async def message(sid, message_type, message_data):
             last_ts, last_observations = Datastore.observation_memory.last_observations(persona_guid)
             last_ts, last_update = Datastore.status_updates.last_update_for_persona(persona_guid)
             recent_sequences = Datastore.sequence_updates.last_updates_for_persona(persona_guid, 10)
+            recent_conversations = Datastore.conversations.get(persona_guid)[-10:]
 
-            options = await API.gaia.create_reactions(last_update, last_observations, recent_sequences, Datastore.meta_affordances, ignore_continue=True)
+            options = await API.gaia.create_reactions(last_update, last_observations, recent_sequences,
+                                                      Datastore.meta_affordances, recent_conversations,ignore_continue=True)
             print("OPTIONS:", options)
             # options = [{'action': 'interact', 'parameters': {'simobject_guid': 'Bank', 'affordance': 'Rob Bank'}}]
             msg = models.Message('choose-sequence-response', {"options": options})
@@ -114,6 +116,7 @@ async def message(sid, message_type, message_data):
         #dt = datetime.datetime.fromisoformat(timestamp_str)
         dt = parser.parse(timestamp_str)
         conversation = models.Conversation.from_dict(dt, json.loads(conversation_raw))
+        Datastore.conversations.add(conversation)
         # TODO: Store the conversation
         # api.datastore.conversations.add_conversation(dt, conversation)
 


### PR DESCRIPTION
indexes the conversations based on npc so the last N conversations that character had are added to the prompt.

```
You had the following conversations recently:
[{"time_ago": "138m ago", "transcript": [{"persona_guid": "wyatt_cooper", "dialogue": "Morning, Dr. Bones. Looks like you've been up to some mischief again. Knocking over coffins at funerals, huh?"}, {"persona_guid": "horatio_bones", "dialogue": "Ah, Sheriff Cooper! My apologies for the commotion. It seems my clumsiness got the best of me once more. But fear not, no harm was done to the deceased or their final resting place."}, {"persona_guid": "wyatt_cooper", "dialogue": "Well, as long as you didn't disturb the peace of the dead, I suppose all is forgiven. But try to be a bit more careful next time, Doc. We don't want any more mishaps at funerals."}]}...
```